### PR TITLE
Fix Java 7 compile; README updates; signed header order

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Request request = Request.builder()
 ```
 
 NOTE: You only need to include headers in your `Request` that will be included
-in the EdgeGrid request signature. Many APIs to not require any headers to be
+in the EdgeGrid request signature. Many APIs do not require any headers to be
 signed.
 
 `EdgeGridV1Signer` is an implementation of the EdgeGrid V1 Signing Algorithm.

--- a/edgegrid-signer-core/pom.xml
+++ b/edgegrid-signer-core/pom.xml
@@ -24,6 +24,10 @@
             <artifactId>logback-classic</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
         </dependency>

--- a/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/ClientCredential.java
+++ b/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/ClientCredential.java
@@ -16,9 +16,9 @@
 
 package com.akamai.edgegrid.signer;
 
-import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.builder.Builder;
@@ -42,7 +42,7 @@ public class ClientCredential implements Comparable<ClientCredential> {
     private String accessToken;
     private String clientSecret;
     private String clientToken;
-    private Set<String> headersToSign;
+    private TreeSet<String> headersToSign;
     private String host;
     private Integer maxBodySize;
 
@@ -132,7 +132,8 @@ public class ClientCredential implements Comparable<ClientCredential> {
         private String accessToken;
         private String clientSecret;
         private String clientToken;
-        private Set<String> headersToSign = new HashSet<>();
+        // NOTE: Headers are expected to be in order, so we pre-sort them here by using TreeSet.
+        private TreeSet<String> headersToSign = new TreeSet<>();
         private String host;
         private Integer maxBodySize;
 

--- a/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/EdgeGridV1Signer.java
+++ b/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/EdgeGridV1Signer.java
@@ -275,6 +275,7 @@ public class EdgeGridV1Signer {
 
     private String canonicalizeHeaders(Map<String, String> requestHeaders, ClientCredential credential) {
         List<String> headers = new ArrayList<>();
+        // NOTE: Headers are expected to be in order. ClientCredential#headersToSign is a TreeSet.
         for (String headerName : credential.getHeadersToSign()) {
             String headerValue = requestHeaders.get(headerName);
             if (StringUtils.isBlank(headerValue)) {

--- a/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/EdgeGridV1Signer.java
+++ b/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/EdgeGridV1Signer.java
@@ -239,7 +239,7 @@ public class EdgeGridV1Signer {
         sb.append(request.getMethod().toUpperCase());
         sb.append('\t');
 
-        String scheme = StringUtils.defaultString(request.getUriWithQuery().getScheme(), "https");
+        String scheme = StringUtils.defaultString(request.getUri().getScheme(), "https");
         sb.append(scheme.toLowerCase());
         sb.append('\t');
 
@@ -247,7 +247,7 @@ public class EdgeGridV1Signer {
         sb.append(host.toLowerCase());
         sb.append('\t');
 
-        String relativePath = getRelativePathWithQuery(request.getUriWithQuery());
+        String relativePath = getRelativePathWithQuery(request.getUri());
         String relativeUrl = canonicalizeUri(relativePath);
         sb.append(relativeUrl);
         sb.append('\t');

--- a/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/EdgeGridV1Signer.java
+++ b/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/EdgeGridV1Signer.java
@@ -16,6 +16,25 @@
 
 package com.akamai.edgegrid.signer;
 
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
@@ -26,18 +45,6 @@ import org.slf4j.LoggerFactory;
 import com.akamai.edgegrid.signer.ClientCredential.ClientCredentialBuilder;
 import com.akamai.edgegrid.signer.Request.RequestBuilder;
 import com.akamai.edgegrid.signer.exceptions.RequestSigningException;
-
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.security.InvalidKeyException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.text.SimpleDateFormat;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 
 /**
@@ -84,8 +91,6 @@ public class EdgeGridV1Signer {
     private static final String SIGNING_ALGORITHM = "HmacSHA256";
 
     private static final Logger log = LoggerFactory.getLogger(EdgeGridV1Signer.class);
-
-    private final Base64.Encoder base64 = Base64.getEncoder();
 
     /**
      * Creates signer with default configuration.
@@ -172,7 +177,7 @@ public class EdgeGridV1Signer {
         String timeStamp = formatTimeStamp(timestamp);
         String authData = getAuthData(credential, timeStamp, nonce);
         String signature = getSignature(request, credential, timeStamp, authData);
-        log.debug(String.format("Signature: '%s'", signature));
+        log.debug("Signature: {}", signature);
 
         return getAuthorizationHeaderValue(authData, signature);
     }
@@ -181,23 +186,21 @@ public class EdgeGridV1Signer {
                                 String authData) throws RequestSigningException {
         String signingKey = getSigningKey(timeStamp, credential.getClientSecret());
         String canonicalizedRequest = getCanonicalizedRequest(request, credential);
-        log.debug(String.format("Canonicalized request: '%s'",
-                StringEscapeUtils.escapeJava(canonicalizedRequest)));
+        log.debug("Canonicalized request: {}", StringEscapeUtils.escapeJava(canonicalizedRequest));
         String dataToSign = getDataToSign(canonicalizedRequest, authData);
-        log.debug(String.format("Data to sign: '%s'",
-                StringEscapeUtils.escapeJava(dataToSign)));
+        log.debug("Data to sign: {}", StringEscapeUtils.escapeJava(dataToSign));
 
         return signAndEncode(dataToSign, signingKey);
     }
 
     private String signAndEncode(String stringToSign, String signingKey) throws RequestSigningException {
         byte[] signatureBytes = sign(stringToSign, signingKey);
-        return base64.encodeToString(signatureBytes);
+        return Base64.encodeBase64String(signatureBytes);
     }
 
     private String getSigningKey(String timeStamp, String clientSecret) throws RequestSigningException {
         byte[] signingKeyBytes = sign(timeStamp, clientSecret);
-        return base64.encodeToString(signingKeyBytes);
+        return Base64.encodeBase64String(signingKeyBytes);
     }
 
     private String getDataToSign(String canonicalizedRequest, String authData) {
@@ -304,18 +307,21 @@ public class EdgeGridV1Signer {
 
         int lengthToHash = requestBody.length;
         if (lengthToHash > maxBodySize) {
-            log.info(String.format("Content length '%d' is larger than the max '%d'. " +
-                    "Using first '%d' bytes for computing the hash.", lengthToHash, maxBodySize, maxBodySize));
+            log.info("Content length '{}' exceeds signing length of '{}'. Less than the entire message will be signed.",
+                    lengthToHash,
+                    maxBodySize);
             lengthToHash = maxBodySize;
         } else {
-            log.debug(String.format("Content (Base64): %s", base64.encodeToString(requestBody)));
+            if (log.isTraceEnabled()) {
+                log.trace("Content (Base64): {}", Base64.encodeBase64String(requestBody));
+            }
         }
 
         byte[] digestBytes = getHash(requestBody, 0, lengthToHash);
-        log.debug(String.format("Content hash (Base64): %s", base64.encodeToString(digestBytes)));
+        log.debug("Content hash (Base64): {}", Base64.encodeBase64String(digestBytes));
 
         // (mgawinec) I removed support for non-retryable content, that used to reset the content for downstream handlers
-        return base64.encodeToString(digestBytes);
+        return Base64.encodeBase64String(digestBytes);
     }
 
 }

--- a/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/EdgeGridV1SignerTest.java
+++ b/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/EdgeGridV1SignerTest.java
@@ -84,7 +84,7 @@ public class EdgeGridV1SignerTest {
                 {"GET request",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("https://any-hostname-at-all.com/check"))
+                                .uri(URI.create("https://any-hostname-at-all.com/check"))
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
                         "EG1-HMAC-SHA256 client_token=akaa-k7glklzuxkkh2ycw-oadjrtwpvpn6yjoj;" +
@@ -94,7 +94,7 @@ public class EdgeGridV1SignerTest {
                 {"GET request with query",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("https://control.akamai.com/check?maciek=value"))
+                                .uri(URI.create("https://control.akamai.com/check?maciek=value"))
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
                         "EG1-HMAC-SHA256 client_token=akaa-k7glklzuxkkh2ycw-oadjrtwpvpn6yjoj;" +
@@ -104,7 +104,7 @@ public class EdgeGridV1SignerTest {
                 {"POST request",
                         Request.builder()
                                 .method("POST")
-                                .uriWithQuery(URI.create("https://any-hostname-at-all.com/send"))
+                                .uri(URI.create("https://any-hostname-at-all.com/send"))
                                 .body("x=y&a=b".getBytes())
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
@@ -114,7 +114,7 @@ public class EdgeGridV1SignerTest {
                 {"For PUT request we ignore body",
                         Request.builder()
                                 .method("PUT")
-                                .uriWithQuery(URI.create("https://control.akamai.com/send"))
+                                .uri(URI.create("https://control.akamai.com/send"))
                                 .body("x=y&a=b".getBytes())
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
@@ -125,7 +125,7 @@ public class EdgeGridV1SignerTest {
                 {"GET without scheme or hostname",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("/check"))
+                                .uri(URI.create("/check"))
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
                         "EG1-HMAC-SHA256 client_token=akaa-k7glklzuxkkh2ycw-oadjrtwpvpn6yjoj;" +
@@ -161,7 +161,7 @@ public class EdgeGridV1SignerTest {
                 {"simple GET",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("/"))
+                                .uri(URI.create("/"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
@@ -173,7 +173,7 @@ public class EdgeGridV1SignerTest {
                 {"GET with querystring",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("/testapi/v1/t1?p1=1&p2=2"))
+                                .uri(URI.create("/testapi/v1/t1?p1=1&p2=2"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
@@ -185,7 +185,7 @@ public class EdgeGridV1SignerTest {
                 {"POST inside limit",
                         Request.builder()
                                 .method("POST")
-                                .uriWithQuery(URI.create("/testapi/v1/t3"))
+                                .uri(URI.create("/testapi/v1/t3"))
                                 .body("datadatadatadatadatadatadatadata".getBytes())
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .build(),
@@ -198,7 +198,7 @@ public class EdgeGridV1SignerTest {
                 {"POST too large",
                         Request.builder()
                                 .method("POST")
-                                .uriWithQuery(URI.create("/testapi/v1/t3"))
+                                .uri(URI.create("/testapi/v1/t3"))
                                 .body(repeat('d', maxSize + 1).getBytes())
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .build(),
@@ -211,7 +211,7 @@ public class EdgeGridV1SignerTest {
                 {"POST too large",
                         Request.builder()
                                 .method("POST")
-                                .uriWithQuery(URI.create("/testapi/v1/t3"))
+                                .uri(URI.create("/testapi/v1/t3"))
                                 .body(repeat('d', maxSize).getBytes())
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .build(),
@@ -224,7 +224,7 @@ public class EdgeGridV1SignerTest {
                 {"POST empty body",
                         Request.builder()
                                 .method("POST")
-                                .uriWithQuery(URI.create("/testapi/v1/t6"))
+                                .uri(URI.create("/testapi/v1/t6"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .body("".getBytes())
                                 .build(),
@@ -237,7 +237,7 @@ public class EdgeGridV1SignerTest {
                 {"Simple header signing with GET",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("/testapi/v1/t4"))
+                                .uri(URI.create("/testapi/v1/t4"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .header("X-Test1", "test-simple-header")
                                 .build(),
@@ -250,7 +250,7 @@ public class EdgeGridV1SignerTest {
                 {"Header with leading and interior spaces",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("/testapi/v1/t4"))
+                                .uri(URI.create("/testapi/v1/t4"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .header("X-Test1", "     first-thing      second-thing")
                                 .build(),
@@ -263,7 +263,7 @@ public class EdgeGridV1SignerTest {
                 {"Headers out of order",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("/testapi/v1/t4"))
+                                .uri(URI.create("/testapi/v1/t4"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .header("X-Test2", "t2")
                                 .header("X-Test1", "t1")
@@ -278,7 +278,7 @@ public class EdgeGridV1SignerTest {
                 {"Extra header",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("/testapi/v1/t5"))
+                                .uri(URI.create("/testapi/v1/t5"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .header("X-Test2", "t2")
                                 .header("X-Test1", "t1")
@@ -294,7 +294,7 @@ public class EdgeGridV1SignerTest {
                 {"PUT test",
                         Request.builder()
                                 .method("PUT")
-                                .uriWithQuery(URI.create("/testapi/v1/t6"))
+                                .uri(URI.create("/testapi/v1/t6"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .body("PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP".getBytes())
                                 .build(),

--- a/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/EdgeGridV1SignerTest.java
+++ b/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/EdgeGridV1SignerTest.java
@@ -84,43 +84,43 @@ public class EdgeGridV1SignerTest {
                 {"GET request",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("http://any-hostname-at-all.com/check"))
+                                .uriWithQuery(URI.create("https://any-hostname-at-all.com/check"))
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
                         "EG1-HMAC-SHA256 client_token=akaa-k7glklzuxkkh2ycw-oadjrtwpvpn6yjoj;" +
                                 "access_token=akaa-dm5g2bfwoodqnc6k-ju7vlao2gz6oz234;" +
-                                "timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=0dCwIUaObZaXrTO1CwojlVBwuNbh1av+nO7VS2YC8is=",
+                                "timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=8GpKbZnIx4XEw/zXtQdbVwIu0zJSG0RpNiVTSyIUwr0=",
                 },
                 {"GET request with query",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("http://control.akamai.com/check?maciek=value"))
+                                .uriWithQuery(URI.create("https://control.akamai.com/check?maciek=value"))
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
                         "EG1-HMAC-SHA256 client_token=akaa-k7glklzuxkkh2ycw-oadjrtwpvpn6yjoj;" +
                                 "access_token=akaa-dm5g2bfwoodqnc6k-ju7vlao2gz6oz234;" +
-                                "timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=OkiBaPX/HORjhPPu2Vyo35aQrO3+GhDM1x4NHXUoOio=",
+                                "timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=x10Wq9yA03bt+1nvPJPgVdReeIp91yLWjR0UPDSbL1Q=",
                 },
                 {"POST request",
                         Request.builder()
                                 .method("POST")
-                                .uriWithQuery(URI.create("http://any-hostname-at-all.com/send"))
+                                .uriWithQuery(URI.create("https://any-hostname-at-all.com/send"))
                                 .body("x=y&a=b".getBytes())
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
                         "EG1-HMAC-SHA256 client_token=akaa-k7glklzuxkkh2ycw-oadjrtwpvpn6yjoj;" +
-                                "access_token=akaa-dm5g2bfwoodqnc6k-ju7vlao2gz6oz234;timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=AY5RxJqWU9EO3iMM1x/Fd6AdsJF8kzz7NYVmyc8QixA=",
+                                "access_token=akaa-dm5g2bfwoodqnc6k-ju7vlao2gz6oz234;timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=fN+xqlaSh0P07vBQ5cSCNK8gCYJfFIltzl6xrTjC6i0=",
                 },
                 {"For PUT request we ignore body",
                         Request.builder()
                                 .method("PUT")
-                                .uriWithQuery(URI.create("http://control.akamai.com/send"))
+                                .uriWithQuery(URI.create("https://control.akamai.com/send"))
                                 .body("x=y&a=b".getBytes())
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
                         "EG1-HMAC-SHA256 client_token=akaa-k7glklzuxkkh2ycw-oadjrtwpvpn6yjoj;" +
                                 "access_token=akaa-dm5g2bfwoodqnc6k-ju7vlao2gz6oz234;" +
-                                "timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=DvV3p2X66F3qHopVX3tk3pHm8vIqLR9aJCKFCgIQS5Q=",
+                                "timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=OFMfMK4ROsW+TTmauMOjyrFuBr7jcJ1b6sb0+jIYj24=",
                 },
                 {"GET without scheme or hostname",
                         Request.builder()

--- a/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/RequestTest.java
+++ b/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/RequestTest.java
@@ -39,13 +39,13 @@ public class RequestTest {
         Request request = Request.builder()
                 .body("body".getBytes())
                 .method("GET")
-                .uriWithQuery(URI.create("http://control.akamai.com/check"))
+                .uriWithQuery(URI.create("https://control.akamai.com/check"))
                 .header("header", "h")
                 .build();
 
         assertThat(request.getBody(), equalTo("body".getBytes()));
         assertThat(request.getMethod(), equalTo("GET"));
-        assertThat(request.getUriWithQuery(), equalTo(URI.create("http://control.akamai.com/check")));
+        assertThat(request.getUriWithQuery(), equalTo(URI.create("https://control.akamai.com/check")));
         assertThat(request.getHeaders().size(), equalTo(1));
         assertThat(request.getHeaders().get("header"), equalTo("h"));
     }
@@ -82,7 +82,7 @@ public class RequestTest {
     public void testRejectDuplicateHeaderNames() throws RequestSigningException {
         Request.builder()
                 .method("GET")
-                .uriWithQuery(URI.create("http://control.akamai.com/check"))
+                .uriWithQuery(URI.create("https://control.akamai.com/check"))
                 .header("Duplicate", "X")
                 .header("Duplicate", "Y")
                 .build();
@@ -92,7 +92,7 @@ public class RequestTest {
     public void testRejectDuplicateCaseInsensitiveHeaderNames() throws RequestSigningException {
         Request.builder()
                 .method("GET")
-                .uriWithQuery(URI.create("http://control.akamai.com/check"))
+                .uriWithQuery(URI.create("https://control.akamai.com/check"))
                 .header("Duplicate", "X")
                 .header("DUPLICATE", "Y")
                 .build();
@@ -102,7 +102,7 @@ public class RequestTest {
     public void testRejectDuplicateHeaderNamesMap() throws RequestSigningException {
         Request.RequestBuilder builder = Request.builder()
                 .method("GET")
-                .uriWithQuery(URI.create("http://control.akamai.com/check"))
+                .uriWithQuery(URI.create("https://control.akamai.com/check"))
                 .header("Duplicate", "X");
         Map<String, String> headers = new HashMap<>();
         headers.put("Duplicate", "y");
@@ -113,7 +113,7 @@ public class RequestTest {
     public void testRejectDuplicateHeaderNamesMixedCase() throws RequestSigningException {
         Request.builder()
                 .method("GET")
-                .uriWithQuery(URI.create("http://control.akamai.com/check"))
+                .uriWithQuery(URI.create("https://control.akamai.com/check"))
                 .header("Duplicate", "X")
                 .header("DUPLICATE", "Y")
                 .build();

--- a/edgegrid-signer-google-http-client/src/main/java/com/akamai/edgegrid/signer/googlehttpclient/GoogleHttpClientEdgeGridRequestSigner.java
+++ b/edgegrid-signer-google-http-client/src/main/java/com/akamai/edgegrid/signer/googlehttpclient/GoogleHttpClientEdgeGridRequestSigner.java
@@ -62,7 +62,7 @@ public class GoogleHttpClientEdgeGridRequestSigner extends AbstractEdgeGridReque
     protected Request map(HttpRequest request) throws RequestSigningException {
         Request.RequestBuilder builder = Request.builder()
                 .method(request.getRequestMethod())
-                .uriWithQuery(request.getUrl().toURI())
+                .uri(request.getUrl().toURI())
                 .body(serializeContent(request));
         for (Map.Entry<String, Object> entry : request.getHeaders().entrySet()) {
             Object value = entry.getValue();

--- a/edgegrid-signer-rest-assured/src/main/java/com/akamai/edgegrid/signer/restassured/RestAssuredEdgeGridRequestSigner.java
+++ b/edgegrid-signer-rest-assured/src/main/java/com/akamai/edgegrid/signer/restassured/RestAssuredEdgeGridRequestSigner.java
@@ -107,7 +107,7 @@ public class RestAssuredEdgeGridRequestSigner extends
 
         Request.RequestBuilder builder = Request.builder()
                 .method(requestSpec.getMethod())
-                .uriWithQuery(URI.create(requestSpec.getURI()))
+                .uri(URI.create(requestSpec.getURI()))
                 .body(serialize(requestSpec.getBody()));
         for (Header header : requestSpec.getHeaders()) {
             builder.header(header.getName(), header.getValue());

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.10</version>
+            </dependency>
+            <dependency>
                 <groupId>com.github.tomakehurst</groupId>
                 <artifactId>wiremock</artifactId>
                 <version>2.1.12</version>


### PR DESCRIPTION
This includes two bug fixes and various updates to the README based on feedback from users.

Bugs:
Java 7 compilation fails due to use of java.util.Base64
Headers to sign were not sorted as needed per EdgeGrid spec