### PR TITLE
Fixed to HTTPS; changed to relative URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EdgeGrid for Java
+# EdgeGrid Client for Java
 
 Java implementation of Akamai {OPEN} EdgeGrid signing in Java.
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ Include the following Maven dependency in your project POM:
 Sign your REST-assured request specification with a defined client credential:
 
 ```java
-given()
-    .baseUri("https://endpoint.net")
+given()    
     .filter(new RestAssuredEdgeGridFilter(credential))
 .when()
     .get("/service/v2/users")

--- a/edgegrid-signer-core/pom.xml
+++ b/edgegrid-signer-core/pom.xml
@@ -11,6 +11,7 @@
 
     <artifactId>edgegrid-signer-core</artifactId>
     <packaging>jar</packaging>
+    <name>EdgeGrid Client for Java</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/AbstractEdgeGridRequestSigner.java
+++ b/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/AbstractEdgeGridRequestSigner.java
@@ -90,9 +90,9 @@ public abstract class AbstractEdgeGridRequestSigner<RequestT> {
      *
      * @param request an HTTP client-specific request
      * @return a {@link Request} representation of {@code request}
-     * @throws RequestSigningException if duplicate header definitions are found
+     * @throws IllegalArgumentException if duplicate header definitions are found
      */
-    protected abstract Request map(RequestT request) throws RequestSigningException;
+    protected abstract Request map(RequestT request) throws IllegalArgumentException;
 
     /**
      * Updates a given HTTP request by adding Authorization header with a value containing request

--- a/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/EdgeGridV1Signer.java
+++ b/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/EdgeGridV1Signer.java
@@ -245,7 +245,7 @@ public class EdgeGridV1Signer {
         sb.append(host.toLowerCase());
         sb.append('\t');
 
-        String relativePath = getRelativePathWithQuery(request.getUriWithQuery());
+        String relativePath = getRelativePathWithQuery(request.getUriPathWithQuery());
         String relativeUrl = canonicalizeUri(relativePath);
         sb.append(relativeUrl);
         sb.append('\t');

--- a/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/EdgeGridV1Signer.java
+++ b/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/EdgeGridV1Signer.java
@@ -236,8 +236,9 @@ public class EdgeGridV1Signer {
         sb.append(request.getMethod().toUpperCase());
         sb.append('\t');
 
-        String scheme = StringUtils.defaultString(request.getUriWithQuery().getScheme(), "https");
-        sb.append(scheme.toLowerCase());
+        // all OPEN APIs use HTTPS, non
+        String scheme = "https";
+        sb.append(scheme);
         sb.append('\t');
 
         String host = credential.getHost();

--- a/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/Request.java
+++ b/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/Request.java
@@ -243,18 +243,6 @@ public class Request implements Comparable<Request> {
         }
 
         /**
-         * Please use {@link #uri(URI)} instead.
-         *
-         * @param uri a {@link URI}
-         * @return reference back to this builder instance
-         * @deprecated
-         */
-        @Deprecated
-        public RequestBuilder uriWithQuery(URI uri) {
-            return uri(uri);
-        }
-
-        /**
          * Returns a newly-created immutable HTTP request.
          */
         @Override

--- a/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/AbstractEdgeGridRequestSignerTest.java
+++ b/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/AbstractEdgeGridRequestSignerTest.java
@@ -54,7 +54,7 @@ public class AbstractEdgeGridRequestSignerTest {
 
         return new AbstractEdgeGridRequestSigner(clientCredentialProvider) {
             @Override
-            protected Request map(Object request) throws RequestSigningException {
+            protected Request map(Object request) {
                 return null;
             }
 

--- a/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/EdgeGridV1SignerTest.java
+++ b/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/EdgeGridV1SignerTest.java
@@ -84,7 +84,7 @@ public class EdgeGridV1SignerTest {
                 {"GET request",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("https://any-hostname-at-all.com/check"))
+                                .uriPathWithQuery(URI.create("/check"))
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
                         "EG1-HMAC-SHA256 client_token=akaa-k7glklzuxkkh2ycw-oadjrtwpvpn6yjoj;" +
@@ -94,8 +94,7 @@ public class EdgeGridV1SignerTest {
                 {"GET request with query",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("https://control.akamai" +
-                                        ".com/check?maciek=value"))
+                                .uriPathWithQuery(URI.create("/check?maciek=value"))
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
                         "EG1-HMAC-SHA256 client_token=akaa-k7glklzuxkkh2ycw-oadjrtwpvpn6yjoj;" +
@@ -105,7 +104,7 @@ public class EdgeGridV1SignerTest {
                 {"POST request",
                         Request.builder()
                                 .method("POST")
-                                .uriWithQuery(URI.create("https://any-hostname-at-all.com/send"))
+                                .uriPathWithQuery(URI.create("/send"))
                                 .body("x=y&a=b".getBytes())
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
@@ -116,7 +115,7 @@ public class EdgeGridV1SignerTest {
                 {"For PUT request we ignore body",
                         Request.builder()
                                 .method("PUT")
-                                .uriWithQuery(URI.create("https://control.akamai.com/send"))
+                                .uriPathWithQuery(URI.create("/send"))
                                 .body("x=y&a=b".getBytes())
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
@@ -127,7 +126,7 @@ public class EdgeGridV1SignerTest {
                 {"GET without scheme or hostname",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("/check"))
+                                .uriPathWithQuery(URI.create("/check"))
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
                         "EG1-HMAC-SHA256 client_token=akaa-k7glklzuxkkh2ycw-oadjrtwpvpn6yjoj;" +
@@ -163,7 +162,7 @@ public class EdgeGridV1SignerTest {
                 {"simple GET",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("/"))
+                                .uriPathWithQuery(URI.create("/"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
@@ -175,7 +174,7 @@ public class EdgeGridV1SignerTest {
                 {"GET with querystring",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("/testapi/v1/t1?p1=1&p2=2"))
+                                .uriPathWithQuery(URI.create("/testapi/v1/t1?p1=1&p2=2"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
@@ -187,7 +186,7 @@ public class EdgeGridV1SignerTest {
                 {"POST inside limit",
                         Request.builder()
                                 .method("POST")
-                                .uriWithQuery(URI.create("/testapi/v1/t3"))
+                                .uriPathWithQuery(URI.create("/testapi/v1/t3"))
                                 .body("datadatadatadatadatadatadatadata".getBytes())
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .build(),
@@ -200,7 +199,7 @@ public class EdgeGridV1SignerTest {
                 {"POST too large",
                         Request.builder()
                                 .method("POST")
-                                .uriWithQuery(URI.create("/testapi/v1/t3"))
+                                .uriPathWithQuery(URI.create("/testapi/v1/t3"))
                                 .body(repeat('d', maxSize + 1).getBytes())
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .build(),
@@ -213,7 +212,7 @@ public class EdgeGridV1SignerTest {
                 {"POST too large",
                         Request.builder()
                                 .method("POST")
-                                .uriWithQuery(URI.create("/testapi/v1/t3"))
+                                .uriPathWithQuery(URI.create("/testapi/v1/t3"))
                                 .body(repeat('d', maxSize).getBytes())
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .build(),
@@ -226,7 +225,7 @@ public class EdgeGridV1SignerTest {
                 {"POST empty body",
                         Request.builder()
                                 .method("POST")
-                                .uriWithQuery(URI.create("/testapi/v1/t6"))
+                                .uriPathWithQuery(URI.create("/testapi/v1/t6"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .body("".getBytes())
                                 .build(),
@@ -239,7 +238,7 @@ public class EdgeGridV1SignerTest {
                 {"Simple header signing with GET",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("/testapi/v1/t4"))
+                                .uriPathWithQuery(URI.create("/testapi/v1/t4"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .header("X-Test1", "test-simple-header")
                                 .build(),
@@ -252,7 +251,7 @@ public class EdgeGridV1SignerTest {
                 {"Header with leading and interior spaces",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("/testapi/v1/t4"))
+                                .uriPathWithQuery(URI.create("/testapi/v1/t4"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .header("X-Test1", "     first-thing      second-thing")
                                 .build(),
@@ -265,7 +264,7 @@ public class EdgeGridV1SignerTest {
                 {"Headers out of order",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("/testapi/v1/t4"))
+                                .uriPathWithQuery(URI.create("/testapi/v1/t4"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .header("X-Test2", "t2")
                                 .header("X-Test1", "t1")
@@ -280,7 +279,7 @@ public class EdgeGridV1SignerTest {
                 {"Extra header",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("/testapi/v1/t5"))
+                                .uriPathWithQuery(URI.create("/testapi/v1/t5"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .header("X-Test2", "t2")
                                 .header("X-Test1", "t1")
@@ -296,7 +295,7 @@ public class EdgeGridV1SignerTest {
                 {"PUT test",
                         Request.builder()
                                 .method("PUT")
-                                .uriWithQuery(URI.create("/testapi/v1/t6"))
+                                .uriPathWithQuery(URI.create("/testapi/v1/t6"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .body("PPPPPPPPPPPPPPPPPPPPPPPPPPPPPPP".getBytes())
                                 .build(),

--- a/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/EdgeGridV1SignerTest.java
+++ b/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/EdgeGridV1SignerTest.java
@@ -104,7 +104,7 @@ public class EdgeGridV1SignerTest {
                 {"POST request",
                         Request.builder()
                                 .method("POST")
-                                .uriWithQuery(URI.create("http://any-hostname-at-all.com/send"))
+                                .uri(URI.create("http://any-hostname-at-all.com/send"))
                                 .body("x=y&a=b".getBytes())
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
@@ -224,7 +224,7 @@ public class EdgeGridV1SignerTest {
                 {"POST empty body",
                         Request.builder()
                                 .method("POST")
-                                .uriWithQuery(URI.create("/testapi/v1/t6"))
+                                .uri(URI.create("/testapi/v1/t6"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .body("".getBytes())
                                 .build(),
@@ -237,7 +237,7 @@ public class EdgeGridV1SignerTest {
                 {"Simple header signing with GET",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("/testapi/v1/t4"))
+                                .uri(URI.create("/testapi/v1/t4"))
                                 .header("Host", "akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net")
                                 .header("X-Test1", "test-simple-header")
                                 .build(),

--- a/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/EdgeGridV1SignerTest.java
+++ b/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/EdgeGridV1SignerTest.java
@@ -84,43 +84,45 @@ public class EdgeGridV1SignerTest {
                 {"GET request",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("http://any-hostname-at-all.com/check"))
+                                .uriWithQuery(URI.create("https://any-hostname-at-all.com/check"))
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
                         "EG1-HMAC-SHA256 client_token=akaa-k7glklzuxkkh2ycw-oadjrtwpvpn6yjoj;" +
                                 "access_token=akaa-dm5g2bfwoodqnc6k-ju7vlao2gz6oz234;" +
-                                "timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=0dCwIUaObZaXrTO1CwojlVBwuNbh1av+nO7VS2YC8is=",
+                                "timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=8GpKbZnIx4XEw/zXtQdbVwIu0zJSG0RpNiVTSyIUwr0=",
                 },
                 {"GET request with query",
                         Request.builder()
                                 .method("GET")
-                                .uriWithQuery(URI.create("http://control.akamai.com/check?maciek=value"))
+                                .uriWithQuery(URI.create("https://control.akamai" +
+                                        ".com/check?maciek=value"))
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
                         "EG1-HMAC-SHA256 client_token=akaa-k7glklzuxkkh2ycw-oadjrtwpvpn6yjoj;" +
                                 "access_token=akaa-dm5g2bfwoodqnc6k-ju7vlao2gz6oz234;" +
-                                "timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=OkiBaPX/HORjhPPu2Vyo35aQrO3+GhDM1x4NHXUoOio=",
+                                "timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=x10Wq9yA03bt+1nvPJPgVdReeIp91yLWjR0UPDSbL1Q=",
                 },
                 {"POST request",
                         Request.builder()
                                 .method("POST")
-                                .uriWithQuery(URI.create("http://any-hostname-at-all.com/send"))
-                                .body("x=y&a=b".getBytes())
-                                .build(),
-                        clientCredential, fixedTimestamp, fixedNonce,
-                        "EG1-HMAC-SHA256 client_token=akaa-k7glklzuxkkh2ycw-oadjrtwpvpn6yjoj;" +
-                                "access_token=akaa-dm5g2bfwoodqnc6k-ju7vlao2gz6oz234;timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=AY5RxJqWU9EO3iMM1x/Fd6AdsJF8kzz7NYVmyc8QixA=",
-                },
-                {"For PUT request we ignore body",
-                        Request.builder()
-                                .method("PUT")
-                                .uriWithQuery(URI.create("http://control.akamai.com/send"))
+                                .uriWithQuery(URI.create("https://any-hostname-at-all.com/send"))
                                 .body("x=y&a=b".getBytes())
                                 .build(),
                         clientCredential, fixedTimestamp, fixedNonce,
                         "EG1-HMAC-SHA256 client_token=akaa-k7glklzuxkkh2ycw-oadjrtwpvpn6yjoj;" +
                                 "access_token=akaa-dm5g2bfwoodqnc6k-ju7vlao2gz6oz234;" +
-                                "timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=DvV3p2X66F3qHopVX3tk3pHm8vIqLR9aJCKFCgIQS5Q=",
+                                "timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=fN+xqlaSh0P07vBQ5cSCNK8gCYJfFIltzl6xrTjC6i0=",
+                },
+                {"For PUT request we ignore body",
+                        Request.builder()
+                                .method("PUT")
+                                .uriWithQuery(URI.create("https://control.akamai.com/send"))
+                                .body("x=y&a=b".getBytes())
+                                .build(),
+                        clientCredential, fixedTimestamp, fixedNonce,
+                        "EG1-HMAC-SHA256 client_token=akaa-k7glklzuxkkh2ycw-oadjrtwpvpn6yjoj;" +
+                                "access_token=akaa-dm5g2bfwoodqnc6k-ju7vlao2gz6oz234;" +
+                                "timestamp=20160804T07:00:00+0000;nonce=ec9d20ee-1e9b-4c1f-925a-f0017754f86c;signature=OFMfMK4ROsW+TTmauMOjyrFuBr7jcJ1b6sb0+jIYj24=",
                 },
                 {"GET without scheme or hostname",
                         Request.builder()

--- a/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/RequestTest.java
+++ b/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/RequestTest.java
@@ -109,7 +109,7 @@ public class RequestTest {
     public void testRejectDuplicateHeaderNames() {
         Request.builder()
                 .method("GET")
-                .uriWithQuery(URI.create("http://control.akamai.com/check"))
+                .uri(URI.create("http://control.akamai.com/check"))
                 .header("Duplicate", "X")
                 .header("Duplicate", "Y")
                 .build();
@@ -119,7 +119,7 @@ public class RequestTest {
     public void testRejectDuplicateCaseInsensitiveHeaderNames() {
         Request.builder()
                 .method("GET")
-                .uriWithQuery(URI.create("http://control.akamai.com/check"))
+                .uri(URI.create("http://control.akamai.com/check"))
                 .header("Duplicate", "X")
                 .header("DUPLICATE", "Y")
                 .build();
@@ -129,7 +129,7 @@ public class RequestTest {
     public void testRejectDuplicateHeaderNamesMap() {
         Request.RequestBuilder builder = Request.builder()
                 .method("GET")
-                .uriWithQuery(URI.create("http://control.akamai.com/check"))
+                .uri(URI.create("http://control.akamai.com/check"))
                 .header("Duplicate", "X");
         Map<String, String> headers = new HashMap<>();
         headers.put("Duplicate", "y");
@@ -140,7 +140,7 @@ public class RequestTest {
     public void testRejectDuplicateHeaderNamesMixedCase() {
         Request.builder()
                 .method("GET")
-                .uriWithQuery(URI.create("http://control.akamai.com/check"))
+                .uri(URI.create("http://control.akamai.com/check"))
                 .header("Duplicate", "X")
                 .header("DUPLICATE", "Y")
                 .build();

--- a/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/RequestTest.java
+++ b/edgegrid-signer-core/src/test/java/com/akamai/edgegrid/signer/RequestTest.java
@@ -35,90 +35,97 @@ import com.akamai.edgegrid.signer.exceptions.RequestSigningException;
 public class RequestTest {
 
     @Test
-    public void testAcceptRequestWithAbsoluteUri() throws RequestSigningException {
+    public void testAcceptRequestWithAbsoluteUri() {
         Request request = Request.builder()
                 .body("body".getBytes())
                 .method("GET")
-                .uriWithQuery(URI.create("http://control.akamai.com/check"))
+                .uriPathWithQuery(URI.create("/check"))
                 .header("header", "h")
                 .build();
 
         assertThat(request.getBody(), equalTo("body".getBytes()));
         assertThat(request.getMethod(), equalTo("GET"));
-        assertThat(request.getUriWithQuery(), equalTo(URI.create("http://control.akamai.com/check")));
+        assertThat(request.getUriPathWithQuery(), equalTo(URI.create("/check")));
         assertThat(request.getHeaders().size(), equalTo(1));
         assertThat(request.getHeaders().get("header"), equalTo("h"));
     }
 
     @Test
-    public void testAcceptRequestWithRelativeUri() throws RequestSigningException {
+    public void testAcceptRequestWithRelativeUri() {
         Request request = Request.builder()
                 .body("body".getBytes())
                 .method("GET")
-                .uriWithQuery(URI.create("/check"))
+                .uriPathWithQuery(URI.create("/check"))
                 .header("header", "h")
                 .build();
 
         assertThat(request.getBody(), equalTo("body".getBytes()));
         assertThat(request.getMethod(), equalTo("GET"));
-        assertThat(request.getUriWithQuery(), equalTo(URI.create("/check")));
+        assertThat(request.getUriPathWithQuery(), equalTo(URI.create("/check")));
         assertThat(request.getHeaders().size(), equalTo(1));
         assertThat(request.getHeaders().get("header"), equalTo("h"));
     }
 
     @Test
-    public void testHeadersLowercasing() throws RequestSigningException {
+    public void testHeadersLowercasing() {
         Request request = Request.builder()
                 .body("body".getBytes())
                 .method("GET")
-                .uriWithQuery(URI.create("/check"))
+                .uriPathWithQuery(URI.create("/check"))
                 .header("HeaDer", "h")
                 .build();
 
         assertThat(request.getHeaders().get("header"), equalTo("h"));
     }
 
-    @Test(expectedExceptions = RequestSigningException.class)
-    public void testRejectDuplicateHeaderNames() throws RequestSigningException {
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testRejectDuplicateHeaderNames() {
         Request.builder()
                 .method("GET")
-                .uriWithQuery(URI.create("http://control.akamai.com/check"))
+                .uriPathWithQuery(URI.create("/check"))
                 .header("Duplicate", "X")
                 .header("Duplicate", "Y")
                 .build();
     }
 
-    @Test(expectedExceptions = RequestSigningException.class)
-    public void testRejectDuplicateCaseInsensitiveHeaderNames() throws RequestSigningException {
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testRejectDuplicateCaseInsensitiveHeaderNames() {
         Request.builder()
                 .method("GET")
-                .uriWithQuery(URI.create("http://control.akamai.com/check"))
+                .uriPathWithQuery(URI.create("/check"))
                 .header("Duplicate", "X")
                 .header("DUPLICATE", "Y")
                 .build();
     }
 
-    @Test(expectedExceptions = RequestSigningException.class)
-    public void testRejectDuplicateHeaderNamesMap() throws RequestSigningException {
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testRejectDuplicateHeaderNamesMap() {
         Request.RequestBuilder builder = Request.builder()
                 .method("GET")
-                .uriWithQuery(URI.create("http://control.akamai.com/check"))
+                .uriPathWithQuery(URI.create("/check"))
                 .header("Duplicate", "X");
         Map<String, String> headers = new HashMap<>();
         headers.put("Duplicate", "y");
         builder.headers(headers);
     }
 
-    @Test(expectedExceptions = RequestSigningException.class)
-    public void testRejectDuplicateHeaderNamesMixedCase() throws RequestSigningException {
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testRejectDuplicateHeaderNamesMixedCase() {
         Request.builder()
                 .method("GET")
-                .uriWithQuery(URI.create("http://control.akamai.com/check"))
+                .uriPathWithQuery(URI.create("/check"))
                 .header("Duplicate", "X")
                 .header("DUPLICATE", "Y")
                 .build();
     }
 
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testRejectRequestWithAbsoluteUri(){
+        Request.builder()
+                .method("GET")
+                .uriPathWithQuery(URI.create("https://absolute.com/check"))
+                .build();
+    }
 
 
 }

--- a/edgegrid-signer-google-http-client/pom.xml
+++ b/edgegrid-signer-google-http-client/pom.xml
@@ -11,6 +11,7 @@
 
     <artifactId>edgegrid-signer-google-http-client</artifactId>
     <packaging>jar</packaging>
+    <name>EdgeGrid Client binding for Google HTTP Client Library for Java</name>
 
     <dependencies>
         <dependency>

--- a/edgegrid-signer-rest-assured/pom.xml
+++ b/edgegrid-signer-rest-assured/pom.xml
@@ -11,6 +11,7 @@
 
     <artifactId>edgegrid-signer-rest-assured</artifactId>
     <packaging>jar</packaging>
+    <name>EdgeGrid Client binding for REST-assured</name>
 
     <dependencies>
         <dependency>

--- a/edgegrid-signer-rest-assured/src/main/java/com/akamai/edgegrid/signer/restassured/RestAssuredEdgeGridRequestSigner.java
+++ b/edgegrid-signer-rest-assured/src/main/java/com/akamai/edgegrid/signer/restassured/RestAssuredEdgeGridRequestSigner.java
@@ -78,6 +78,11 @@ public class RestAssuredEdgeGridRequestSigner extends
         }
     }
 
+    private static URI getRelativePath(String uriString) {
+        final URI uri = URI.create(uriString);
+        return URI.create(uri.getPath() + "?" + uri.getQuery());
+    }
+
     /**
      * Creates an EdgeGrid request signer using the same {@link ClientCredential} for all requests.
      *
@@ -99,16 +104,16 @@ public class RestAssuredEdgeGridRequestSigner extends
     }
 
     @Override
-    protected Request map(FilterableRequestSpecification requestSpec)
-            throws RequestSigningException {
+    protected Request map(FilterableRequestSpecification requestSpec) {
 
         Validate.isTrue(requestSpec.getMultiPartParams().isEmpty(),
                 "multipart request is not supported");
 
         Request.RequestBuilder builder = Request.builder()
                 .method(requestSpec.getMethod())
-                .uriWithQuery(URI.create(requestSpec.getURI()))
+                .uriPathWithQuery(getRelativePath(requestSpec.getURI()))
                 .body(serialize(requestSpec.getBody()));
+
         for (Header header : requestSpec.getHeaders()) {
             builder.header(header.getName(), header.getValue());
         }

--- a/edgegrid-signer-rest-assured/src/test/java/com/akamai/edgegrid/signer/restassured/RestAssuredEdgeGridFilterTest.java
+++ b/edgegrid-signer-rest-assured/src/test/java/com/akamai/edgegrid/signer/restassured/RestAssuredEdgeGridFilterTest.java
@@ -82,7 +82,6 @@ public class RestAssuredEdgeGridFilterTest {
         RestAssured.given()
                 .relaxedHTTPSValidation()
                 .filter(new RestAssuredEdgeGridFilter(credential))
-                .baseUri("https://ignored-hostname.com")
                 .get("/billing-usage/v1/reportSources")
                 .then().statusCode(200);
     }
@@ -102,7 +101,6 @@ public class RestAssuredEdgeGridFilterTest {
                 .relaxedHTTPSValidation()
                 .filter(new RestAssuredEdgeGridFilter(credential))
                 .header("Host", "ignored-hostname.com")
-                .baseUri("https://ignored-hostname.com")
                 .get("/billing-usage/v1/reportSources")
                 .then().statusCode(200);
     }
@@ -121,7 +119,6 @@ public class RestAssuredEdgeGridFilterTest {
 
         RestAssured.given()
                 .filter(new RestAssuredEdgeGridFilter(credential))
-                .baseUri("https://ignored-hostname.com")
                 .body(new File("/home/johan/some_large_file.bin"))
                 .post("/billing-usage/v1/reportSources")
                 .then().statusCode(200);
@@ -132,7 +129,6 @@ public class RestAssuredEdgeGridFilterTest {
 
         RestAssured.given()
                 .filter(new RestAssuredEdgeGridFilter(credential))
-                .baseUri("https://ignored-hostname.com")
                 .body(new ByteArrayInputStream("exampleString".getBytes(StandardCharsets.UTF_8)))
                 .post("/billing-usage/v1/reportSources")
         .then().statusCode(200);
@@ -143,7 +139,6 @@ public class RestAssuredEdgeGridFilterTest {
 
         RestAssured.given()
                 .filter(new RestAssuredEdgeGridFilter(credential))
-                .baseUri("https://ignored-hostname.com")
                 .multiPart("file", new File("/home/johan/some_large_file.bin"))
                 .post("/billing-usage/v1/reportSources")
                 .then().statusCode(200);

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <packaging>pom</packaging>
 
     <url>https://github.com/akamai-open/AkamaiOPEN-edgegrid-java</url>
-    <name>AkamaiOPEN-edgegrid-java</name>
+    <name>Parent for EdgeGrid Client for Java</name>
     <description>
         Signs HTTP requests to OPEN API services, using EdgeGrid V1 signing algorithm.
     </description>


### PR DESCRIPTION
I fixed host to be always HTTPS, as discussed over email.

I removed baseURI from REST-assured examples, as proposed in my review to your pull request.

I removed depracated uriWithQuery method. I don't want to release new public API with methods already depracated.

In  Maven Central submodules had no names disaplayed: https://maven-repository.com/artifact/com.akamai.edgegrid. I updated POMs.