### PR TITLE
Bugfix/21

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,35 @@ HttpGet request = new HttpGet("http://endpoint.net/billing-usage/v1/reportSource
 client.execute(request);
 ```
 
+There's also a possibility to use Apache HTTP Client in combination with REST-assured. First, you 
+need to define `HttpClientFactory`:
+
+```java
+public HttpClientFactory getSigningHttpClientFactory() {
+    return new HttpClientConfig.HttpClientFactory() {
+            @Override
+            public HttpClient createHttpClient() {
+                final DefaultHttpClient client = new DefaultHttpClient();
+                client.addRequestInterceptor(new ApacheHttpClientEdgeGridInterceptor(clientCredential));
+                client.setRoutePlanner(new ApacheHttpClientEdgeGridRoutePlanner(clientCredential));
+                return client;
+            }
+        };
+}
+```
+
+Next, make `REST-assured` use it:
+
+```java
+given()
+    .config()
+        .httpClient(HttpClientConfig.httpClientConfig().httpClientFactory(getSigningHttpClientFactory()))
+.when()
+    .get("/billing-usage/v1/reportSources")
+.then()
+    .statusCode(200);
+```
+
 ## Releases
 
 2.1:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Include the following Maven dependency in your project POM:
 <dependency>
     <groupId>com.akamai.edgegrid</groupId>
     <artifactId>edgegrid-signer-rest-assured</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 </dependency>
 ```
 
@@ -125,7 +125,7 @@ Include the following Maven dependency in your project POM:
 <dependency>
     <groupId>com.akamai.edgegrid</groupId>
     <artifactId>edgegrid-signer-google-http-client</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
 </dependency>
 ```
 
@@ -173,7 +173,36 @@ mechanism to construct a `ClientCredential` at the time of a request based on
 any logic you may want. For example, your own implementation could read
 credentials from a database or other secret store.
 
+## Usage with Apache HTTP Client 
+
+There is an EdgeGrid signer implementation for [Apache HTTP Client][13].
+
+Include the following Maven dependency in your project POM:
+
+```xml
+<dependency>
+    <groupId>com.akamai.edgegrid</groupId>
+    <artifactId>edgegrid-signer-apache-http-client</artifactId>
+    <version>2.1.0</version>
+</dependency>
+```
+
+Create an HTTP client that will sign your HTTP request with a defined client credential:
+
+```java
+HttpClient client = HttpClientBuilder.create()
+                .addInterceptorFirst(new ApacheHttpClientEdgeGridInterceptor(clientCredential))
+                .setRoutePlanner(new ApacheHttpClientEdgeGridRoutePlanner(clientCredential))
+                .build();
+
+HttpGet request = new HttpGet("http://endpoint.net/billing-usage/v1/reportSources");
+client.execute(request);
+```
+
 ## Releases
+
+2.1:
+- binding for Apache HTTP Client
 
 2.0:
 
@@ -208,6 +237,7 @@ programming languages:
 [10]: https://github.com/rest-assured/rest-assured
 [11]: https://developer.akamai.com/introduction/Client_Auth.html
 [12]: https://developer.akamai.com/
+[13]: https://hc.apache.org/
 
 ## Authors
 

--- a/edgegrid-signer-apache-http-client/pom.xml
+++ b/edgegrid-signer-apache-http-client/pom.xml
@@ -53,6 +53,11 @@
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/edgegrid-signer-apache-http-client/pom.xml
+++ b/edgegrid-signer-apache-http-client/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>edgegrid-signer-parent</artifactId>
+        <groupId>com.akamai.edgegrid</groupId>
+        <version>2.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>edgegrid-signer-apache-http-client</artifactId>
+    <packaging>jar</packaging>
+    <name>Apache HTTP Client Library binding for EdgeGrid Client</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.akamai.edgegrid</groupId>
+            <artifactId>edgegrid-signer-core</artifactId>
+            <version>2.1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+        </dependency>
+        <!-- Apache HTTP Client library uses JCL. -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/edgegrid-signer-apache-http-client/src/main/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridInterceptor.java
+++ b/edgegrid-signer-apache-http-client/src/main/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridInterceptor.java
@@ -1,0 +1,57 @@
+package com.akamai.edgegrid.signer.apachehttpclient;
+
+
+import com.akamai.edgegrid.signer.ClientCredential;
+import com.akamai.edgegrid.signer.ClientCredentialProvider;
+import com.akamai.edgegrid.signer.Request;
+import com.akamai.edgegrid.signer.exceptions.RequestSigningException;
+
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.protocol.HttpContext;
+
+import java.io.IOException;
+
+/**
+ * Apache HTTP Client Library interceptor that signs a request using EdgeGrid V1 signing algorithm.
+ * Signing is a process of adding an Authorization header with a request signature. If signing fails then <code>RuntimeException</code> is thrown.
+ *
+ * @see <a href="https://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/org/apache/http/HttpRequestInterceptor.html">HttpRequestInterceptor</a> from Apache HTTP Client
+ * @author mgawinec@akamai.com
+ */
+public class ApacheHttpClientEdgeGridInterceptor implements HttpRequestInterceptor {
+
+    private final ApacheHttpClientEdgeGridRequestSigner binding;
+
+    /**
+     * Creates an EdgeGrid signing interceptor using the same {@link ClientCredential} for each
+     * request.
+     *
+     * @param credential a {@link ClientCredential}
+     */
+    public ApacheHttpClientEdgeGridInterceptor(ClientCredential credential) {
+        this.binding = new ApacheHttpClientEdgeGridRequestSigner(credential);
+    }
+
+    /**
+     * Creates an EdgeGrid signing interceptor selecting a {@link ClientCredential} via
+     * {@link ClientCredentialProvider#getClientCredential(Request)} for each request.
+     *
+     * @param clientCredentialProvider a {@link ClientCredentialProvider}
+     */
+    public ApacheHttpClientEdgeGridInterceptor(ClientCredentialProvider clientCredentialProvider) {
+        this.binding = new ApacheHttpClientEdgeGridRequestSigner(clientCredentialProvider);
+    }
+
+    @Override
+    public void process(HttpRequest request, HttpContext context) throws HttpException, IOException {
+        try {
+            binding.sign(request);
+        } catch (RequestSigningException e) {
+            throw new RuntimeException(e);
+        } finally {
+            System.out.println("Signed");
+        }
+    }
+}

--- a/edgegrid-signer-apache-http-client/src/main/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridRequestSigner.java
+++ b/edgegrid-signer-apache-http-client/src/main/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridRequestSigner.java
@@ -1,0 +1,109 @@
+package com.akamai.edgegrid.signer.apachehttpclient;
+
+import com.akamai.edgegrid.signer.AbstractEdgeGridRequestSigner;
+import com.akamai.edgegrid.signer.ClientCredential;
+import com.akamai.edgegrid.signer.ClientCredentialProvider;
+import com.akamai.edgegrid.signer.Request;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
+import org.apache.http.HttpRequest;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.HttpRequestWrapper;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.entity.BufferedHttpEntity;
+import org.apache.http.impl.client.RequestWrapper;
+import org.apache.http.util.EntityUtils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Apache HTTP Client binding for EdgeGrid signer for signing {@link HttpRequest}.
+ *
+ * @author mgawinec@akamai.com
+ */
+public class ApacheHttpClientEdgeGridRequestSigner extends AbstractEdgeGridRequestSigner<HttpRequest> {
+
+    public ApacheHttpClientEdgeGridRequestSigner(ClientCredential clientCredential) {
+        super(clientCredential);
+    }
+
+    public ApacheHttpClientEdgeGridRequestSigner(ClientCredentialProvider clientCredentialProvider) {
+        super(clientCredentialProvider);
+    }
+
+    @Override
+    protected Request map(HttpRequest request) {
+        Request.RequestBuilder builder = Request.builder()
+                .method(request.getRequestLine().getMethod())
+                .uri(request.getRequestLine().getUri())
+                .body(serializeContent(request));
+        for (Header h : request.getAllHeaders()) {
+            builder.header(h.getName(), h.getValue());
+        }
+
+        return builder.build();
+    }
+
+    private byte[] serializeContent(HttpRequest request) {
+        if (!(request instanceof HttpEntityEnclosingRequest)) {
+            return new byte[]{};
+        }
+
+        final HttpEntityEnclosingRequest entityWithRequest = (HttpEntityEnclosingRequest) request;
+        HttpEntity entity = entityWithRequest.getEntity();
+        if (entity == null) {
+            return new byte[]{};
+        }
+
+        try {
+            // Buffer non-repeatable entities
+            if (!entity.isRepeatable()) {
+                entityWithRequest.setEntity(new BufferedHttpEntity(entity));
+            }
+            return EntityUtils.toByteArray(entityWithRequest.getEntity());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected void setAuthorization(HttpRequest request, String signature) {
+        request.setHeader("Authorization", signature);
+    }
+
+    @Override
+    protected void setHost(HttpRequest request, String host) {
+        request.setHeader("Host", host);
+
+        if (request instanceof HttpRequestWrapper) {
+            setHost(((HttpRequestWrapper) request).getOriginal(), host);
+        } else if (request instanceof RequestWrapper) {
+            setHost(((RequestWrapper) request).getOriginal(), host);
+        } else {
+            URI oldUri = ((HttpRequestBase) request).getURI();
+            try {
+                URI newUri = replaceHost(oldUri, host);
+                ((HttpRequestBase) request).setURI(newUri);
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static URI replaceHost(URI oldUri, String host) throws URISyntaxException {
+        return new URIBuilder()
+                .setScheme(oldUri.getScheme())
+                .setHost(host)
+                .setPort(oldUri.getPort())
+                .setPath(oldUri.getPath())
+                .setParameters(URLEncodedUtils.parse(oldUri, "UTF-8"))
+                .setFragment(oldUri.getFragment())
+                .build();
+    }
+
+}

--- a/edgegrid-signer-apache-http-client/src/main/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridRoutePlanner.java
+++ b/edgegrid-signer-apache-http-client/src/main/java/com/akamai/edgegrid/signer/apachehttpclient/ApacheHttpClientEdgeGridRoutePlanner.java
@@ -1,0 +1,41 @@
+package com.akamai.edgegrid.signer.apachehttpclient;
+
+
+
+import com.akamai.edgegrid.signer.ClientCredential;
+import com.akamai.edgegrid.signer.ClientCredentialProvider;
+import com.akamai.edgegrid.signer.exceptions.NoMatchingCredentialException;
+
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.impl.conn.DefaultRoutePlanner;
+import org.apache.http.impl.conn.DefaultSchemePortResolver;
+import org.apache.http.protocol.HttpContext;
+
+public class ApacheHttpClientEdgeGridRoutePlanner extends DefaultRoutePlanner {
+
+    private final ApacheHttpClientEdgeGridRequestSigner binding;
+
+    public ApacheHttpClientEdgeGridRoutePlanner(ClientCredential clientCredential) {
+        super(DefaultSchemePortResolver.INSTANCE);
+        this.binding = new ApacheHttpClientEdgeGridRequestSigner(clientCredential);
+    }
+
+    public ApacheHttpClientEdgeGridRoutePlanner(ClientCredentialProvider clientCredentialProvider) {
+        super(DefaultSchemePortResolver.INSTANCE);
+        this.binding = new ApacheHttpClientEdgeGridRequestSigner(clientCredentialProvider);
+    }
+
+    @Override
+    public HttpRoute determineRoute(HttpHost host, HttpRequest request, HttpContext context) throws HttpException {
+        try {
+            ClientCredential clientCredential = binding.getClientCredentialProvider().getClientCredential(binding.map(request));
+            HttpHost target = HttpHost.create("https://" + clientCredential.getHost());
+            return super.determineRoute(target, request, context);
+        } catch (NoMatchingCredentialException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/edgegrid-signer-apache-http-client/src/test/java/apachehttpclient/ApacheHttpClientEdgeGridInterceptorIntegrationTest.java
+++ b/edgegrid-signer-apache-http-client/src/test/java/apachehttpclient/ApacheHttpClientEdgeGridInterceptorIntegrationTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2016 Copyright 2016 Akamai Technologies, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package apachehttpclient;
+
+
+import com.akamai.edgegrid.signer.ClientCredential;
+import com.akamai.edgegrid.signer.apachehttpclient.ApacheHttpClientEdgeGridInterceptor;
+import com.akamai.edgegrid.signer.apachehttpclient.ApacheHttpClientEdgeGridRoutePlanner;
+import com.akamai.edgegrid.signer.exceptions.RequestSigningException;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.matching.RequestPattern;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+
+/**
+ * Integration tests for {@link com.akamai.edgegrid.signer.apachehttpclient.ApacheHttpClientEdgeGridInterceptor}.
+ *
+ * @author mgawinec@akamai.com
+ * @author mmeyer@akamai.com
+ */
+public class ApacheHttpClientEdgeGridInterceptorIntegrationTest {
+
+    static final String SERVICE_MOCK_HOST = "localhost";
+    static final int SERVICE_MOCK_PORT = 9089;
+    static final String SERVICE_MOCK = SERVICE_MOCK_HOST + ":" + SERVICE_MOCK_PORT;
+
+    ClientCredential credential = ClientCredential.builder()
+            .accessToken("akaa-dm5g2bfwoodqnc6k-ju7vlao2wz6oz2rp")
+            .clientToken("akaa-k7glklzuxkkh2ycw-oadjphopvpn6yjoj")
+            .clientSecret("SOMESECRET")
+            .host(SERVICE_MOCK)
+            .build();
+
+    WireMockServer wireMockServer = new WireMockServer(wireMockConfig().httpsPort(SERVICE_MOCK_PORT));
+
+    @BeforeClass
+    public void setUp() {
+        wireMockServer.start();
+    }
+
+    @BeforeMethod
+    public void reset() {
+        wireMockServer.resetMappings();
+        wireMockServer.resetRequests();
+    }
+
+    @Test
+    public void testInterceptor() throws URISyntaxException, IOException, RequestSigningException {
+
+        wireMockServer.stubFor(get(urlPathEqualTo("/billing-usage/v1/reportSources"))
+                .withHeader("Authorization", matching(".*"))
+                .withHeader("Host", equalTo(SERVICE_MOCK))
+                .willReturn(aResponse()
+                        .withStatus(302)
+                        .withHeader("Location", "/billing-usage/v1/reportSources/alternative")));
+
+        wireMockServer.stubFor(get(urlPathEqualTo("/billing-usage/v1/reportSources/alternative"))
+                .withHeader("Authorization", matching(".*"))
+                .withHeader("Host", equalTo(SERVICE_MOCK))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody("<response>Some content</response>")));
+
+
+        HttpGet request = new HttpGet("http://endpoint.net/billing-usage/v1/reportSources");
+
+        HttpClient client = getHttpClientWithRelaxedSsl()
+                .addInterceptorFirst(new ApacheHttpClientEdgeGridInterceptor(credential))
+                .setRoutePlanner(new ApacheHttpClientEdgeGridRoutePlanner(credential))
+                .build();
+
+        client.execute(request);
+
+        List<LoggedRequest> loggedRequests = wireMockServer.findRequestsMatching(RequestPattern
+                .everything()).getRequests();
+
+        MatcherAssert.assertThat(loggedRequests.get(0).getHeader("Authorization"),
+                Matchers.not(CoreMatchers.equalTo(loggedRequests.get(1).getHeader("Authorization"))));
+    }
+
+    private static HttpClientBuilder getHttpClientWithRelaxedSsl() {
+        return HttpClientBuilder.create()
+                .setSSLContext(trustAllCertificates())
+                .setSSLHostnameVerifier(trustAllHosts());
+    }
+
+    private static HostnameVerifier trustAllHosts() {
+        return new HostnameVerifier() {
+            @Override
+            public boolean verify(String s, SSLSession sslSession) {
+                return true;
+            }
+        };
+    }
+
+    @AfterClass
+    public void tearDownAll() {
+        wireMockServer.stop();
+    }
+
+    private static SSLContext trustAllCertificates() {
+        // set up a TrustManager that trusts everything
+        try {
+            SSLContext sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, new TrustManager[]{new X509TrustManager() {
+                public X509Certificate[] getAcceptedIssuers() {
+                    return null;
+                }
+
+                public void checkClientTrusted(X509Certificate[] certs,
+                                               String authType) {
+                }
+
+                public void checkServerTrusted(X509Certificate[] certs,
+                                               String authType) {
+                }
+            }}, new SecureRandom());
+            return sslContext;
+        } catch (KeyManagementException | NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/edgegrid-signer-apache-http-client/src/test/java/apachehttpclient/ApacheHttpClientEdgeGridInterceptorIntegrationTest.java
+++ b/edgegrid-signer-apache-http-client/src/test/java/apachehttpclient/ApacheHttpClientEdgeGridInterceptorIntegrationTest.java
@@ -111,7 +111,7 @@ public class ApacheHttpClientEdgeGridInterceptorIntegrationTest {
 
         HttpGet request = new HttpGet("http://endpoint.net/billing-usage/v1/reportSources");
 
-        HttpClient client = getHttpClientWithRelaxedSsl()
+        HttpClient client = HttpClientSetup.getHttpClientWithRelaxedSsl()
                 .addInterceptorFirst(new ApacheHttpClientEdgeGridInterceptor(credential))
                 .setRoutePlanner(new ApacheHttpClientEdgeGridRoutePlanner(credential))
                 .build();
@@ -125,46 +125,10 @@ public class ApacheHttpClientEdgeGridInterceptorIntegrationTest {
                 Matchers.not(CoreMatchers.equalTo(loggedRequests.get(1).getHeader("Authorization"))));
     }
 
-    private static HttpClientBuilder getHttpClientWithRelaxedSsl() {
-        return HttpClientBuilder.create()
-                .setSSLContext(trustAllCertificates())
-                .setSSLHostnameVerifier(trustAllHosts());
-    }
-
-    private static HostnameVerifier trustAllHosts() {
-        return new HostnameVerifier() {
-            @Override
-            public boolean verify(String s, SSLSession sslSession) {
-                return true;
-            }
-        };
-    }
-
     @AfterClass
     public void tearDownAll() {
         wireMockServer.stop();
     }
 
-    private static SSLContext trustAllCertificates() {
-        // set up a TrustManager that trusts everything
-        try {
-            SSLContext sslContext = SSLContext.getInstance("SSL");
-            sslContext.init(null, new TrustManager[]{new X509TrustManager() {
-                public X509Certificate[] getAcceptedIssuers() {
-                    return null;
-                }
 
-                public void checkClientTrusted(X509Certificate[] certs,
-                                               String authType) {
-                }
-
-                public void checkServerTrusted(X509Certificate[] certs,
-                                               String authType) {
-                }
-            }}, new SecureRandom());
-            return sslContext;
-        } catch (KeyManagementException | NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-    }
 }

--- a/edgegrid-signer-apache-http-client/src/test/java/apachehttpclient/ApacheHttpClientEdgeGridRequestSignerTest.java
+++ b/edgegrid-signer-apache-http-client/src/test/java/apachehttpclient/ApacheHttpClientEdgeGridRequestSignerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 Copyright 2016 Akamai Technologies, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package apachehttpclient;
+
+
+import com.akamai.edgegrid.signer.ClientCredential;
+import com.akamai.edgegrid.signer.apachehttpclient.ApacheHttpClientEdgeGridRequestSigner;
+import com.akamai.edgegrid.signer.exceptions.RequestSigningException;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.client.methods.HttpGet;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+
+/**
+ * Example of use of EdgeGrid signer with Apache HTTP Client.
+ *
+ * @author mgawinec@akamai.com
+ * @author mmeyer@akamai.com
+ */
+public class ApacheHttpClientEdgeGridRequestSignerTest {
+
+    ClientCredential credential = ClientCredential.builder()
+            .accessToken("akaa-dm5g2bfwoodqnc6k-ju7vlao2wz6oz2rp")
+            .clientToken("akaa-k7glklzuxkkh2ycw-oadjphopvpn6yjoj")
+            .clientSecret("SOMESECRET")
+            .host("endpoint.net")
+            .build();
+
+    @Test
+    public void signEachRequest() throws URISyntaxException, IOException, RequestSigningException {
+
+        HttpRequest request = new HttpGet("https://ignored-hostname.com/billing-usage/v1/reportSources");
+
+        ApacheHttpClientEdgeGridRequestSigner apacheHttpSinger = new ApacheHttpClientEdgeGridRequestSigner(credential);
+        apacheHttpSinger.sign(request);
+
+
+        assertThat(URI.create(request.getRequestLine().getUri()).getHost(), equalTo("endpoint.net"));
+        assertThat(request.getFirstHeader("Authorization"), notNullValue());
+        assertThat(request.getFirstHeader("Authorization").getValue(), not(isEmptyOrNullString()));
+    }
+
+}

--- a/edgegrid-signer-apache-http-client/src/test/java/apachehttpclient/HttpClientSetup.java
+++ b/edgegrid-signer-apache-http-client/src/test/java/apachehttpclient/HttpClientSetup.java
@@ -1,0 +1,58 @@
+package apachehttpclient;
+
+
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+public class HttpClientSetup {
+
+
+    public static HttpClientBuilder getHttpClientWithRelaxedSsl() {
+        return HttpClientBuilder.create()
+                .setSSLContext(trustAllCertificates())
+                .setSSLHostnameVerifier(trustAllHosts());
+    }
+
+    private static HostnameVerifier trustAllHosts() {
+        return new HostnameVerifier() {
+            @Override
+            public boolean verify(String s, SSLSession sslSession) {
+                return true;
+            }
+        };
+    }
+
+    private static SSLContext trustAllCertificates() {
+        // set up a TrustManager that trusts everything
+        try {
+            SSLContext sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, new TrustManager[]{new X509TrustManager() {
+                public X509Certificate[] getAcceptedIssuers() {
+                    return null;
+                }
+
+                public void checkClientTrusted(X509Certificate[] certs,
+                                               String authType) {
+                }
+
+                public void checkServerTrusted(X509Certificate[] certs,
+                                               String authType) {
+                }
+            }}, new SecureRandom());
+            return sslContext;
+        } catch (KeyManagementException | NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/AbstractEdgeGridRequestSigner.java
+++ b/edgegrid-signer-core/src/main/java/com/akamai/edgegrid/signer/AbstractEdgeGridRequestSigner.java
@@ -60,6 +60,11 @@ public abstract class AbstractEdgeGridRequestSigner<RequestT> {
         this.edgeGridSigner = new EdgeGridV1Signer();
     }
 
+
+    public final ClientCredentialProvider getClientCredentialProvider() {
+        return clientCredentialProvider;
+    }
+
     /**
      * Signs {@code request} with appropriate credentials using EdgeGrid signer algorithm and
      * replaces {@code request}'s host name with the one specified by the credential.

--- a/edgegrid-signer-google-http-client/pom.xml
+++ b/edgegrid-signer-google-http-client/pom.xml
@@ -32,6 +32,10 @@
             <artifactId>google-http-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
         </dependency>

--- a/edgegrid-signer-google-http-client/src/test/java/com/akamai/edgegrid/signer/googlehttpclient/GoogleHttpClientEdgeGridInterceptorIntegrationTest.java
+++ b/edgegrid-signer-google-http-client/src/test/java/com/akamai/edgegrid/signer/googlehttpclient/GoogleHttpClientEdgeGridInterceptorIntegrationTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2016 Copyright 2016 Akamai Technologies, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.akamai.edgegrid.signer.googlehttpclient;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpRequestInitializer;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.apache.ApacheHttpTransport;
+
+import com.akamai.edgegrid.signer.ClientCredential;
+import com.akamai.edgegrid.signer.exceptions.RequestSigningException;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.matching.RequestPattern;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+
+/**
+ * Integration tests for {@link GoogleHttpClientEdgeGridInterceptor}.
+ *
+ * @author mgawinec@akamai.com
+ * @author mmeyer@akamai.com
+ */
+public class GoogleHttpClientEdgeGridInterceptorIntegrationTest {
+
+    static final String SERVICE_MOCK_HOST = "localhost";
+    static final int SERVICE_MOCK_PORT = 9089;
+    static final String SERVICE_MOCK = SERVICE_MOCK_HOST + ":" + SERVICE_MOCK_PORT;
+
+    ClientCredential credential = ClientCredential.builder()
+            .accessToken("akaa-dm5g2bfwoodqnc6k-ju7vlao2wz6oz2rp")
+            .clientToken("akaa-k7glklzuxkkh2ycw-oadjphopvpn6yjoj")
+            .clientSecret("SOMESECRET")
+            .host(SERVICE_MOCK)
+            .build();
+
+    WireMockServer wireMockServer = new WireMockServer(wireMockConfig().httpsPort(SERVICE_MOCK_PORT));
+
+
+    @BeforeClass
+    public void setUp() {
+        wireMockServer.start();
+    }
+
+    @BeforeMethod
+    public void reset() {
+        wireMockServer.resetMappings();
+        wireMockServer.resetRequests();
+    }
+
+    @Test
+    public void testInterceptor() throws URISyntaxException, IOException, RequestSigningException {
+
+        wireMockServer.stubFor(get(urlPathEqualTo("/billing-usage/v1/reportSources"))
+                .withHeader("Authorization", matching(".*"))
+                .withHeader("Host", equalTo(SERVICE_MOCK))
+                .willReturn(aResponse()
+                        .withStatus(302)
+                        .withHeader("Location", "/billing-usage/v1/reportSources/alternative")));
+
+        wireMockServer.stubFor(get(urlPathEqualTo("/billing-usage/v1/reportSources/alternative"))
+                .withHeader("Authorization", matching(".*"))
+                .withHeader("Host", equalTo(SERVICE_MOCK))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/xml")
+                        .withBody("<response>Some content</response>")));
+
+        HttpRequestFactory requestFactory = createSigningRequestFactory();
+
+        URI uri = URI.create("https://endpoint.net/billing-usage/v1/reportSources");
+        HttpRequest request = requestFactory.buildGetRequest(new GenericUrl(uri));
+        // Mimic what the library does to process the interceptor.
+        request.setFollowRedirects(true).execute();
+
+        List<LoggedRequest> loggedRequests = wireMockServer.findRequestsMatching(RequestPattern
+                .everything()).getRequests();
+        MatcherAssert.assertThat(loggedRequests.get(0).getHeader("Authorization"),
+                Matchers.not(CoreMatchers.equalTo(loggedRequests.get(1).getHeader("Authorization"))));
+
+    }
+
+    @AfterClass
+    public void tearDownAll() {
+        wireMockServer.stop();
+    }
+
+    private HttpRequestFactory createSigningRequestFactory() {
+        HttpTransport httpTransport = null;
+        try {
+            httpTransport = new ApacheHttpTransport.Builder().doNotValidateCertificate().build();
+        } catch (GeneralSecurityException e) {
+            throw new RuntimeException(e);
+        }
+
+        return httpTransport.createRequestFactory(new HttpRequestInitializer() {
+            @Override
+            public void initialize(HttpRequest request) throws IOException {
+                request.setInterceptor(new GoogleHttpClientEdgeGridInterceptor(credential));
+            }
+        });
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <module>edgegrid-signer-core</module>
         <module>edgegrid-signer-rest-assured</module>
         <module>edgegrid-signer-google-http-client</module>
+        <module>edgegrid-signer-apache-http-client</module>
     </modules>
 
     <packaging>pom</packaging>


### PR DESCRIPTION
Binding for Apache HTTP Client resolves the redirect issue #21 both when used alone and in combination with REST-assured.

It also provides support for signing files and streams that pure REST-assured binding did not provide.